### PR TITLE
removing junk text from 03-compute-resources.md

### DIFF
--- a/docs/03-compute-resources.md
+++ b/docs/03-compute-resources.md
@@ -116,7 +116,7 @@ aws ec2 authorize-security-group-ingress --group-id $SECURITYGROUP --protocol al
 List the firewall rules in the `kubernetes-the-hard-way` VPC network:
 
 ```
-aws ec2 describe-security-group-rules --filter Name="group-id",Values=$SECURITYGROUP --output text                                  <aws:jobboard-dev>
+aws ec2 describe-security-group-rules --filter Name="group-id",Values=$SECURITYGROUP --output text
 ```
 
 > output


### PR DESCRIPTION
I believe junk text was added to this field. When you are viewing the MD file, you get the button to click to copy the command, and this text "<aws:jobboard-dev>" comes along. 